### PR TITLE
Add keyword default color to js/ts this keyword

### DIFF
--- a/themes/vscodechesteratom.json
+++ b/themes/vscodechesteratom.json
@@ -291,6 +291,13 @@
       }
     },
     {
+        "name": "js ts this",
+        "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
+        "settings": {
+            "foreground": "#89BDE4"
+        }
+    },
+    {
       "name": "Invalid",
       "scope": "invalid",
       "settings": {


### PR DESCRIPTION
Javascript `this` keyword seems to be ignored as a default vscode langage keyword for js/ts files.

This pr offers to use the same default blue color scheme, #89BDE4, already used for langage keywords, for `this` in js/ts.

<img width="758" alt="this colored" src="https://user-images.githubusercontent.com/606754/45746779-4f3ba480-bc04-11e8-89e6-9c85df58309f.png">

Without `this` coloring:

<img width="756" alt="this not colored" src="https://user-images.githubusercontent.com/606754/45746876-91fd7c80-bc04-11e8-9010-76b507643dfd.png">

Meanwhile, the option can be set manually in vscode's user settings with:

```
"editor.tokenColorCustomizations": {
    "textMateRules": [
        {
            "name": "js ts this",
            "scope": "var.this,variable.language.this.js,variable.language.this.ts,variable.language.this.jsx,variable.language.this.tsx",
            "settings": {
                "foreground": "#89BDE4"
            }
        }
    ]
}
```