### PR TITLE
Improve treeview selected working file contrast

### DIFF
--- a/themes/vscodechesteratom.json
+++ b/themes/vscodechesteratom.json
@@ -16,6 +16,8 @@
     "input.background": "#242D38",
     "input.border": "#37404E",
     "list.focusBackground": "#215D8C",
+    "list.activeSelectionBackground": "#222a34",
+    "list.inactiveSelectionBackground": "#222a34",
     "tab.inactiveBackground": "#242D38",
     "editorGroupHeader.tabsBackground": "#212934",
     "titleBar.activeBackground": "#242D38",


### PR DESCRIPTION
The editor's current line has a good contrast, but the treeview doesn't use the same color for the selected file.
This update offers to use the same color in the treeview for current file than in the editor for the current line.